### PR TITLE
Change README.rst to README.md in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 from constrainedfilefield import __version__
 
-with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
+with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
     README = readme.read()
 
 # allow setup.py to be run from any path


### PR DESCRIPTION
pip was falling over when trying to install because setup.py refers to README.rst but the repository has README.md instead. This just corrects setup.py (this seemed slightly easier than using pandoc to reformat the Markdown to RST and switching the readmes around).