### PR TITLE
Windows support for magic

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ Installation
 
  * Download and install package with python setup.py install.
  * Note that this package depends on python-magic (to check field types).
+ * For windows, you must download the files at https://github.com/pidydx/libmagicwin64, add them to C:\Windows\System32, and set MAGIC_FILE_PATH="..." in your settings.py.
  * Add 'validatedfile' to your INSTALLED_APPS in settings.py.
 
 Validate single file

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Installation
 
  * Download and install package with python setup.py install.
  * Note that this package depends on python-magic (to check field types).
- * For windows, you must download the files at https://github.com/pidydx/libmagicwin64, add them to C:\Windows\System32, and set MAGIC_FILE_PATH="..." in your settings.py.
+ * For windows, you must download the dll files and .magic file at https://github.com/pidydx/libmagicwin64 (32-bit version: http://gnuwin32.sourceforge.net/packages/file.htm)), add them to C:\\Windows\\System32 (or to a folder in your PATH), and set MAGIC_FILE_PATH="..." to the path of your .magic file in your settings.py. For more information about the files to download, go to: https://github.com/ahupp/python-magic/blob/43df08c5ed63d7aad839695f311ca1be2eeb1ecb/README.md#dependencies
  * Add 'validatedfile' to your INSTALLED_APPS in settings.py.
 
 Validate single file

--- a/validatedfile/fields.py
+++ b/validatedfile/fields.py
@@ -22,7 +22,7 @@ class ValidatedFileField(models.FileField):
             uploaded_content_type = getattr(file, 'content_type', '')
 
             magic_file_path = getattr(settings, "MAGIC_FILE_PATH", None)
-            if (magic_file_path):
+            if magic_file_path:
                 mg = magic.Magic(mime=True, magic_file=magic_file_path)
             else:
                 mg = magic.Magic(mime=True)

--- a/validatedfile/fields.py
+++ b/validatedfile/fields.py
@@ -3,6 +3,7 @@ from django import forms
 from django.template.defaultfilters import filesizeformat
 from django.utils.translation import ugettext as _
 from django.conf import settings
+import os
 
 import magic
 
@@ -20,9 +21,10 @@ class ValidatedFileField(models.FileField):
 
         if self.content_types:
             uploaded_content_type = getattr(file, 'content_type', '')
-
+            
+            # magic_file_path used only for Windows.
             magic_file_path = getattr(settings, "MAGIC_FILE_PATH", None)
-            if magic_file_path:
+            if magic_file_path and os.name == 'nt':
                 mg = magic.Magic(mime=True, magic_file=magic_file_path)
             else:
                 mg = magic.Magic(mime=True)

--- a/validatedfile/fields.py
+++ b/validatedfile/fields.py
@@ -2,6 +2,7 @@ from django.db import models
 from django import forms
 from django.template.defaultfilters import filesizeformat
 from django.utils.translation import ugettext as _
+from django.conf import settings
 
 import magic
 
@@ -20,7 +21,11 @@ class ValidatedFileField(models.FileField):
         if self.content_types:
             uploaded_content_type = getattr(file, 'content_type', '')
 
-            mg = magic.Magic(mime=True)
+            magic_file_path = getattr(settings, "MAGIC_FILE_PATH", None)
+            if (magic_file_path):
+                mg = magic.Magic(mime=True, magic_file=magic_file_path)
+            else:
+                mg = magic.Magic(mime=True)
             content_type_magic = mg.from_buffer(
                 file.read(self.mime_lookup_length)
             )


### PR DESCRIPTION
In Windows, magic must be initialized with the kwarg magic_file that gives the path of the .magic file. This PR:

- Allows for Windows support by allowing the .magic file to be specified by the MAGIC_FILE_PATH setting in settings.py.
- Further documentation in the README to describe how to set this up on Windows.

(Similar PR on original repository here: https://github.com/kaleidos/django-validated-file/pull/13)