### PR TITLE
Updated install requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setup(
         '': ['*.po', '*.mo'],
     },
     install_requires=[
-        'django>=1.8,<2.0; python_version<"3.7"',
-        'django>=2.0; python_version>="3.4"',
+        'django>=1.8,<2.0; python_version<="3.0"',
+        'django>=1.8; python_version>="3.4"',
     ],
     tests_require=TESTS_REQUIRE,
     extras_require={


### PR DESCRIPTION
#  Updated install requires.

In my project we use Python 3.5 and Django 1.11 (LTS). In ``setup.py`` you have following: 

     install_requires=[
       'django>=1.8,<2.0; python_version<="3.7"',
       'django>=2.0; python_version>="3.4"',
     ],

In case of my project python version satisfied both condition but only the latter was taken into account by pip (technically I was using [`pip-tools`](https://github.com/jazzband/pip-tools). And I got following error: 

      Could not find a version that matches django<1.12,>=2.0

I fixed install requires so they reflect current django dependencies: 

1. If we are on python ``2.7.X`` (``<3.0``) we don't support django ``2.0``
2. On python 3.4 or greater django 2.0 is supported (along with 1.8+)

It fixed my error at least ;) 